### PR TITLE
TypeError: Unicode-objects must be encoded before hashing

### DIFF
--- a/tempmail.py
+++ b/tempmail.py
@@ -76,7 +76,7 @@ class TempMail(object):
 
         :param email: email address for generate md5 hash.
         """
-        return md5(email).hexdigest()
+        return md5(email.encode()).hexdigest()
 
     def get_mailbox(self, email=None, email_hash=None):
         """


### PR DESCRIPTION
I'm getting this error with python 3.5.
The code works now for python 2.7.x and python 3
